### PR TITLE
HCK-7485: fix re api disconnect parameters inconsistency

### DIFF
--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -62,7 +62,7 @@ module.exports = {
 		}
 	},
 
-	disconnect: function (connectionInfo, cb, app) {
+	disconnect: function (connectionInfo, logger, cb, app) {
 		cassandraHelper(app.require('lodash')).close(app);
 		cb();
 	},
@@ -80,7 +80,7 @@ module.exports = {
 					logger.log('info', 'Connection successful', 'Test connection');
 				}
 
-				this.disconnect(connectionInfo, () => {}, app);
+				this.disconnect(connectionInfo, logger, () => {}, app);
 
 				return cb(cassandraHelper(app.require('lodash')).prepareError(error));
 			},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7485" title="HCK-7485" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-7485</a>  The disconnect action in plugin doesn’t work properly (all targets affected)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

Used the `(connectionInfo, logger, cb, app)` argument set for disconnect function as with other endpoints to make the API consistent.