### PR TITLE
HCK-14120: fix the generation of an alter script for pk/ck if new values ​​do not exist

### DIFF
--- a/forward_engineering/helpers/updateHelpers/tableHelper.js
+++ b/forward_engineering/helpers/updateHelpers/tableHelper.js
@@ -132,11 +132,6 @@ const hydrateColumn = ({ tableName, keyspaceName, isOldModel, property, udtMap, 
 	};
 };
 
-const getTableParameter = (item, key) => {
-	const parameter = item?.role?.compMod?.[key];
-	return parameter?.new || item?.role?.[key];
-};
-
 const addToKeysHashType = (keysHash, keys) => {
 	return Object.entries(keysHash).reduce((keysHash, [id, key]) => {
 		const type = (keys.find(key => key.keyId === id) || {}).type;
@@ -229,8 +224,8 @@ const getAddTable = addTableData => {
 	}
 	let table = addTableData.item;
 	const data = addTableData.data;
-	const compositePartitionKey = getTableParameter(table, 'compositePartitionKey') || [];
-	const compositeClusteringKey = getTableParameter(table, 'compositeClusteringKey') || [];
+	const compositePartitionKey = table?.role?.compMod?.compositePartitionKey?.new || [];
+	const compositeClusteringKey = table?.role?.compMod?.compositeClusteringKey?.new || [];
 
 	const entityData = [
 		{
@@ -270,7 +265,6 @@ module.exports = {
 	alterTablePrefix,
 	hydrateColumn,
 	isTableChange,
-	getTableParameter,
 	addScriptToExistScripts,
 	getDeleteTable,
 	getAddTable,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14120" title="HCK-14120" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-14120</a>  [ScyllaDB]: Fix altering partition/clustering keys if property no longer exist
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

If the new value doesn't exist in the comp mode, the keys must be empty. Taking the value from the role object is incorrect.